### PR TITLE
Add Search Bar

### DIFF
--- a/css/map.css
+++ b/css/map.css
@@ -43,6 +43,18 @@ body {
 	font-size: 12px;
 }
 
+.geocoder {
+  position: absolute;
+  z-index: 1;
+  width: 40%;
+  left: 10px;
+  top: 110px;
+}
+
+.mapboxgl-ctrl-geocoder {
+  min-width: 100%;
+}
+
 .dot {
 	height: 10px;
 	width: 10px;

--- a/index.html
+++ b/index.html
@@ -6,7 +6,9 @@
     <title>Newcomer Service Providers in Canada</title>
     <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
     <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js'></script>
+    <script src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v4.4.1/mapbox-gl-geocoder.min.js'></script>
     <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css' rel='stylesheet' />
+    <link rel='stylesheet' href='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v4.4.1/mapbox-gl-geocoder.css' type='text/css' />
     <link href='css/map.css' rel='stylesheet' />
 </head>
 
@@ -16,6 +18,7 @@
     </header>
     <nav id="menu"></nav>
     <div id='map'></div>
+    <div id='geocoder' class='geocoder'></div>
     <main id='main'>
         <p>Student research project, Electronic Business Technologies (EBT), University of Ottawa</p>
         <p>Student: Yu Mi (Final Report)</br>

--- a/index.html
+++ b/index.html
@@ -4,11 +4,11 @@
 <head>
     <meta charset='utf-8' />
     <title>Newcomer Service Providers in Canada</title>
-    <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
-    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js'></script>
-    <script src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v4.4.1/mapbox-gl-geocoder.min.js'></script>
-    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css' rel='stylesheet' />
-    <link rel='stylesheet' href='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v4.4.1/mapbox-gl-geocoder.css' type='text/css' />
+       <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
+    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.1.1/mapbox-gl.js'></script>
+    <script src='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-directions/v4.0.2/mapbox-gl-directions.js'></script>
+    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.1.1/mapbox-gl.css' rel='stylesheet' />
+    <link rel='stylesheet' href='https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-directions/v4.0.2/mapbox-gl-directions.css' type='text/css' />
     <link href='css/map.css' rel='stylesheet' />
 </head>
 
@@ -18,7 +18,6 @@
     </header>
     <nav id="menu"></nav>
     <div id='map'></div>
-    <div id='geocoder' class='geocoder'></div>
     <main id='main'>
         <p>Student research project, Electronic Business Technologies (EBT), University of Ottawa</p>
         <p>Student: Yu Mi (Final Report)</br>

--- a/js/map.js
+++ b/js/map.js
@@ -8,12 +8,11 @@ var map = new mapboxgl.Map({
     zoom: 4.11
 });
 
-var geocoder = new MapboxGeocoder({
+var directions = new MapboxDirections({
   accessToken: mapboxgl.accessToken,
-  mapboxgl: mapboxgl
+  unit: 'metric',
 });
-
-document.getElementById('geocoder').appendChild(geocoder.onAdd(map));
+map.addControl(directions, 'bottom-left');
 
 // When the page loads, define this funtionality
 map.on('load', function() {

--- a/js/map.js
+++ b/js/map.js
@@ -8,6 +8,13 @@ var map = new mapboxgl.Map({
     zoom: 4.11
 });
 
+var geocoder = new MapboxGeocoder({
+  accessToken: mapboxgl.accessToken,
+  mapboxgl: mapboxgl
+});
+
+document.getElementById('geocoder').appendChild(geocoder.onAdd(map));
+
 // When the page loads, define this funtionality
 map.on('load', function() {
 


### PR DESCRIPTION
As per issue request to add search bar. The search bar can search by address, city, region, district, and postal code. 

Search bar removed to add directions instead. This feature is more useful to the user because it can both allow the user to search for a location and find out how to get to the destination. There are four types of directions: traffic, driving, walking, and cycling. However, map does not zoom in enough when the start location is identified.